### PR TITLE
chore(aiwf): catch up to v0.1.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ After `/compact` or a fresh session, this file is re-available via the system pr
 
 - **NEVER commit or push without explicit human approval** — "continue" / "ok" do not count
 - **TDD by default** for logic, API, and data code — red → green → refactor
+- **TDD phase tracking** — logic-bearing ACs in `draft` and `in_progress` milestones carry a `tdd_phase: red|green|refactor` field, advanced via `aiwf promote M-NNN/AC-N --phase <p>`. Non-logic ACs (doc-only, gap-closure, full-suite gates, branch-coverage audit, process discipline) omit the field. Every red-tagged AC must reach green before the milestone wraps.
 - **Branch coverage** — every reachable conditional branch needs a test before declaring done; perform a line-by-line audit before the commit-approval prompt
 - **Branch discipline** — do NOT commit milestone work directly to `main`
 - Conventional Commits format: `feat(api):`, `fix(sim):`, `chore:`, `docs:`, `test:`, `refactor:` — no icons/emoji; subject + short bullet body capturing the milestone and key work/tests touched
@@ -55,7 +56,9 @@ Role agents ship via the `aiwf-extensions` plugin (loaded into Claude Code from 
 | `work/archived-epics/<slug>/` | pre-aiwf historical epics (no E-NN id; out of aiwf's walked roots) |
 | `.claude/skills/aiwf-*/` | gitignored, materialized by `aiwf init` / `aiwf update` |
 
-`aiwf` verbs: `init`, `add <kind>`, `promote`, `cancel`, `rename`, `reallocate`, `move`, `check`, `history`, `status`, `render roadmap`, `doctor`, `import`, `schema`, `template`, `contract verify`. Run `aiwf help` for the full list. Don't edit entity frontmatter status by hand — use `aiwf promote` so the FSM check + commit trailer happen.
+`aiwf` verbs: `init`, `update`, `upgrade`, `add <kind>`, `promote`, `cancel`, `rename`, `reallocate`, `move`, `check`, `history`, `status`, `show <id>`, `render roadmap`, `doctor`, `import`, `schema`, `template`, `whoami`, `authorize`, `contract verify|bind|unbind|recipes|recipe show|recipe install|recipe remove`. Run `aiwf help` for the full list. Don't edit entity frontmatter status by hand — use `aiwf promote` so the FSM check + commit trailer happen. Use `aiwf promote/cancel <id> --audit-only --reason "..."` to backfill an audit trail for a state already reached via a manual commit (empty-diff audit commit, no FSM transition).
+
+Provenance: human verbs need no extra flags. Non-human actors (ai/..., bot/...) must pass `--principal human/<id>` and operate inside an active `aiwf authorize <id> --to <agent>` scope; the kernel adds `aiwf-principal:`, `aiwf-on-behalf-of:`, and `aiwf-authorized-by:` trailers automatically. `aiwf authorize` is human-only.
 
 Tracking docs (per the `aiwfx-track` skill) are advisory free-form markdown alongside a milestone spec; not aiwf entities, not validated. Older `*-log.md` / `*-tracking.md` files in `work/archived-epics/` are pre-aiwf residue.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # aiwf status — 2026-05-03
 
-_171 entities · 0 errors · 2 warnings · run `aiwf check` for details_
+_171 entities · 0 errors · 0 warnings_
 
 ## In flight
 
@@ -80,10 +80,7 @@ _(none)_
 
 ## Warnings
 
-| Code | Entity | Path | Message |
-|------|--------|------|---------|
-| acs-title-prose | M-067/AC-9 | work/epics/E-25-engine-truth-gate/M-067-engine-template-alignment.md | M-067/AC-9 title looks like prose (long / multi-sentence / contains markdown); shorten the title and move detail prose into the body section under \`### AC-9\` |
-| acs-title-prose | M-068/AC-14 | work/epics/E-25-engine-truth-gate/M-068-golden-output-canary.md | M-068/AC-14 title looks like prose (long / multi-sentence / contains markdown); shorten the title and move detail prose into the body section under \`### AC-14\` |
+_(none)_
 
 ## Recent activity
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
-# aiwf status — 2026-05-02
+# aiwf status — 2026-05-03
 
-_171 entities · 0 errors · 0 warnings_
+_171 entities · 0 errors · 2 warnings · run `aiwf check` for details_
 
 ## In flight
 
@@ -80,7 +80,10 @@ _(none)_
 
 ## Warnings
 
-_(none)_
+| Code | Entity | Path | Message |
+|------|--------|------|---------|
+| acs-title-prose | M-067/AC-9 | work/epics/E-25-engine-truth-gate/M-067-engine-template-alignment.md | M-067/AC-9 title looks like prose (long / multi-sentence / contains markdown); shorten the title and move detail prose into the body section under \`### AC-9\` |
+| acs-title-prose | M-068/AC-14 | work/epics/E-25-engine-truth-gate/M-068-golden-output-canary.md | M-068/AC-14 title looks like prose (long / multi-sentence / contains markdown); shorten the title and move detail prose into the body section under \`### AC-14\` |
 
 ## Recent activity
 

--- a/aiwf.yaml
+++ b/aiwf.yaml
@@ -1,2 +1,1 @@
-aiwf_version: dev
-actor: human/peter
+aiwf_version: v0.1.1

--- a/work/epics/E-25-engine-truth-gate/M-067-engine-template-alignment.md
+++ b/work/epics/E-25-engine-truth-gate/M-067-engine-template-alignment.md
@@ -37,7 +37,7 @@ acs:
     status: open
     tdd_phase: red
   - id: AC-9
-    title: Engine change is introduced via a failing test first; the same test passes in the commit that lands the engine change
+    title: TDD red-green for engine change
     status: open
   - id: AC-10
     title: Branch coverage on val-warn delta gate
@@ -69,7 +69,7 @@ The `val-warn` delta gate is a small extension to the existing test: track valid
 
 ## Acceptance criteria
 
-### AC-1 — Engine reflects the m-E25-01 chosen authority
+### AC-1 — Engine reflects the authority chosen in M-066
 
 The engine code change implements the authority specified in `D-NNN (the m-E25-01 outcome)`. The cited decision id is filled into this spec, into the implementing PR's description, and into the relevant code comments at the changed sites in `src/FlowTime.Core/`. The change is *exactly* what the decision authorizes — no opportunistic refactoring of `InvariantAnalyzer`, no conservation-tolerance reshaping, no new analyser warning families. Per the epic's "Out of scope" — engine evolution beyond what the design call requires belongs to other epics.
 

--- a/work/epics/E-25-engine-truth-gate/M-067-engine-template-alignment.md
+++ b/work/epics/E-25-engine-truth-gate/M-067-engine-template-alignment.md
@@ -6,31 +6,38 @@ parent: E-25
 depends_on: [M-066]
 acs:
   - id: AC-1
-    title: Engine reflects the m-E25-01 chosen authority
+    title: Engine reflects the authority chosen in M-066
     status: open
+    tdd_phase: red
   - id: AC-2
     title: Affected shipped templates edited under default parameters
     status: open
+    tdd_phase: red
   - id: AC-3
     title: ExpectedRunWarnings entries reset to zero
     status: open
+    tdd_phase: red
   - id: AC-4
     title: Engine + template + baseline reset land in coordinated commits
     status: open
   - id: AC-5
     title: val-warn delta gate added alongside existing run-warn gate
     status: open
+    tdd_phase: red
   - id: AC-6
     title: Both survey gates green simultaneously
     status: open
+    tdd_phase: red
   - id: AC-7
     title: No coexistence of old and new authority paths
     status: open
+    tdd_phase: red
   - id: AC-8
     title: edge_flow_mismatch warnings are zero across shipped templates
     status: open
+    tdd_phase: red
   - id: AC-9
-    title: TDD red-green for engine change
+    title: Engine change is introduced via a failing test first; the same test passes in the commit that lands the engine change
     status: open
   - id: AC-10
     title: Branch coverage on val-warn delta gate

--- a/work/epics/E-25-engine-truth-gate/M-068-golden-output-canary.md
+++ b/work/epics/E-25-engine-truth-gate/M-068-golden-output-canary.md
@@ -51,7 +51,7 @@ acs:
     title: G-033 closes
     status: open
   - id: AC-14
-    title: Epic E-25 spec references docs/testing/golden-output-canary.md as the canary contract
+    title: Epic closure housekeeping complete
     status: open
 ---
 
@@ -81,7 +81,7 @@ A new test class lives in `tests/FlowTime.Integration.Tests/` (sibling to `Templ
 
 The canary's fixture serialization format is decided inside this milestone and documented in `docs/testing/golden-output-canary.md`. The decision honors the epic Constraint: *fixtures produce reviewable PR diffs*. JSON-with-stable-key-order is the strawman; alternatives (CSV+JSON-warnings, separate-file-per-series, etc.) are acceptable if reviewability is preserved and the choice is justified. The format choice is recorded in the testing note with a short rationale paragraph.
 
-### AC-3 — Per-fixture directory layout and README
+### AC-3 — Per-fixture directory layout documented in `docs/testing/golden-output-canary.md`
 
 Each pinned template gets a directory at `tests/fixtures/golden-templates/<template-id>/` containing the serialized fixture (per AC-2's chosen format) plus a `README.md` naming **the parameter set used at capture, the capture date, the capture commit hash**. The README is human-readable and stands alone — a future engineer browsing the fixtures directory understands what each fixture pins without external context. The directory naming uses the same `<template-id>` convention as the survey canary's enumeration.
 

--- a/work/epics/E-25-engine-truth-gate/M-068-golden-output-canary.md
+++ b/work/epics/E-25-engine-truth-gate/M-068-golden-output-canary.md
@@ -8,27 +8,33 @@ acs:
   - id: AC-1
     title: Canary infrastructure lands as a sibling test class
     status: open
+    tdd_phase: red
   - id: AC-2
     title: Fixture serialization format chosen and documented
     status: open
   - id: AC-3
-    title: Per-fixture directory layout and README
+    title: Per-fixture directory layout documented in docs/testing/golden-output-canary.md
     status: open
   - id: AC-4
     title: Numeric tolerance documented and applied
     status: open
+    tdd_phase: red
   - id: AC-5
     title: Initial pinning across all 12 shipped templates
     status: open
+    tdd_phase: red
   - id: AC-6
     title: Coverage equivalence with Survey_Templates_For_Warnings enforced
     status: open
+    tdd_phase: red
   - id: AC-7
     title: Sanctioned regeneration workflow exists and is documented
     status: open
+    tdd_phase: red
   - id: AC-8
     title: Deliberate-perturbation failure-mode test fires
     status: open
+    tdd_phase: red
   - id: AC-9
     title: docs/testing/golden-output-canary.md committed
     status: open
@@ -45,7 +51,7 @@ acs:
     title: G-033 closes
     status: open
   - id: AC-14
-    title: Epic closure housekeeping complete
+    title: Epic E-25 spec references docs/testing/golden-output-canary.md as the canary contract
     status: open
 ---
 


### PR DESCRIPTION
Re-do of #7 after the squash-merge inadvertently swept in the unpushed v3 migration history. PR #7 was reverted (#8); the migration history has been merged to origin/main with all individual commits intact, so `aiwf history` works against per-AC promotion trailers.

This PR is the genuine 2-commit catch-up.

## Summary
- `aiwf.yaml`: drop deprecated `actor:` key; pin `aiwf_version: v0.1.1`.
- `CLAUDE.md`: extend verb list (`update`/`upgrade`/`show`/`whoami`/`authorize`/contract subverbs/`--audit-only`); add provenance/principal note; add `tdd_phase` Hard Rule.
- `M-067` & `M-068`: tighten 2 AC titles (`m-E25-01` → `M-066`, `…and README` → `…golden-output-canary.md`); add `tdd_phase: red` selectively to logic-bearing open ACs.

## Verification
- `aiwf doctor`: pin matches binary v0.1.1; clean.
- `aiwf check`: only the historical untrailered-commit warnings (pre-existing on the migration commits — separate cleanup).
- `aiwf show M-067` / `M-068`: `phase` column populated correctly.

## Test plan
- [x] `aiwf doctor` clean
- [x] `aiwf show M-067`, `M-068` show correct phases
- [ ] Squash-merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)